### PR TITLE
feat: add responsive serial-port manager webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gestor de Archivos y Puertos Serie</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Gestor de Archivos y Puertos Serie</h1>
+  </header>
+  <main>
+    <section id="files-section">
+      <h2>Archivos</h2>
+      <div id="files-container"></div>
+    </section>
+    <section id="serial-section">
+      <h2>Puertos Serie</h2>
+      <div class="controls">
+        <button id="scan-ports">Escanear Puertos</button>
+        <select id="ports-list"></select>
+      </div>
+      <div id="port-info"></div>
+      <input type="file" id="file-input" />
+      <button id="send-file" disabled>Enviar al Puerto</button>
+    </section>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,113 @@
+const fileContainer = document.getElementById('files-container');
+const scanBtn = document.getElementById('scan-ports');
+const portsList = document.getElementById('ports-list');
+const portInfo = document.getElementById('port-info');
+const sendBtn = document.getElementById('send-file');
+const fileInput = document.getElementById('file-input');
+
+let currentPort;
+let selectedFile;
+const knownDevices = {
+  '0x2341-0x0043': 'Arduino Uno',
+  '0x0403-0x6001': 'FTDI Serial Device'
+};
+
+async function loadFiles() {
+  try {
+    const res = await fetch('/api/files');
+    if (!res.ok) throw new Error('bad response');
+    const files = await res.json();
+    renderFiles(files);
+  } catch (e) {
+    console.warn('Falling back to fake files', e);
+    const fakeFiles = [
+      { id: 1, title: 'Se perdió', category: 'Error', content: 'Se perdió' },
+      { id: 2, title: 'la conexión', category: 'Error', content: 'la conexión' },
+      { id: 3, title: 'a la base de datos', category: 'Error', content: 'a la base de datos' }
+    ];
+    renderFiles(fakeFiles);
+  }
+}
+
+function renderFiles(files) {
+  fileContainer.innerHTML = '';
+  const grouped = files.reduce((acc, f) => {
+    acc[f.category] = acc[f.category] || [];
+    acc[f.category].push(f);
+    return acc;
+  }, {});
+  Object.keys(grouped).forEach(cat => {
+    const catDiv = document.createElement('div');
+    catDiv.className = 'file-category';
+    const h3 = document.createElement('h3');
+    h3.textContent = cat;
+    catDiv.appendChild(h3);
+    grouped[cat].forEach(file => {
+      const div = document.createElement('div');
+      div.className = 'file-item';
+      div.textContent = file.title;
+      div.addEventListener('click', () => {
+        document.querySelectorAll('.file-item').forEach(el => el.classList.remove('selected'));
+        div.classList.add('selected');
+        selectedFile = file;
+        updateSendState();
+      });
+      catDiv.appendChild(div);
+    });
+    fileContainer.appendChild(catDiv);
+  });
+}
+
+scanBtn.addEventListener('click', async () => {
+  try {
+    const port = await navigator.serial.requestPort();
+    currentPort = port;
+    await port.open({ baudRate: 9600 });
+    const info = port.getInfo();
+    const vid = info.usbVendorId ? `0x${info.usbVendorId.toString(16)}` : '0x0000';
+    const pid = info.usbProductId ? `0x${info.usbProductId.toString(16)}` : '0x0000';
+    const key = `${vid}-${pid}`;
+    const name = knownDevices[key] || 'Desconocido';
+    portsList.innerHTML = `<option>${name}</option>`;
+    portInfo.textContent = `Conectado: ${name}`;
+    updateSendState();
+  } catch (err) {
+    console.error(err);
+    portInfo.textContent = 'No se seleccionó ningún puerto.';
+  }
+});
+
+fileInput.addEventListener('change', () => {
+  const file = fileInput.files[0];
+  if (file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      selectedFile = { title: file.name, content: reader.result };
+      updateSendState();
+    };
+    reader.readAsArrayBuffer(file);
+  }
+});
+
+async function sendFile() {
+  if (!currentPort || !selectedFile) return;
+  const writer = currentPort.writable.getWriter();
+  let data;
+  if (typeof selectedFile.content === 'string') {
+    data = new TextEncoder().encode(selectedFile.content);
+  } else if (selectedFile.content instanceof ArrayBuffer) {
+    data = new Uint8Array(selectedFile.content);
+  } else {
+    data = new TextEncoder().encode(String(selectedFile.content));
+  }
+  await writer.write(data);
+  writer.releaseLock();
+}
+
+sendBtn.addEventListener('click', sendFile);
+
+function updateSendState() {
+  sendBtn.disabled = !(currentPort && selectedFile);
+}
+
+loadFiles();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,60 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+header {
+  background-color: #333;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+main {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  padding: 1rem;
+  gap: 1rem;
+}
+section {
+  flex: 1 1 300px;
+  background: #f5f5f5;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+#files-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.file-category h3 {
+  margin-bottom: 0.25rem;
+}
+.file-item {
+  background: #fff;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.file-item.selected {
+  background: #e0f7fa;
+}
+.controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+@media (max-width: 600px) {
+  main {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- create responsive HTML/CSS/JS web page to load files and interact with serial ports
- implement Web Serial API usage with basic device identification
- fall back to fake files when database is unreachable and allow sending files over the selected port

## Testing
- `npm test` *(fails: enoent missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ae03254e4832ba567f60771a4c378